### PR TITLE
Initial Django 2.0 compatibility commit

### DIFF
--- a/django_mobile_app_distribution/migrations/0001_initial.py
+++ b/django_mobile_app_distribution/migrations/0001_initial.py
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='AndroidApp',
             fields=[
-                ('app_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='django_mobile_app_distribution.App')),
+                ('app_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='django_mobile_app_distribution.App', on_delete=models.deletion.CASCADE)),
                 ('operating_system', models.CharField(default=b'Android', verbose_name='Operating System', max_length=50, editable=False, choices=[(b'iOS', b'iOS'), (b'Android', b'Android')])),
                 ('app_binary', models.FileField(upload_to=django_mobile_app_distribution.models.normalize_android_filename, storage=django.core.files.storage.FileSystemStorage(location=b'/Users/moritz/Alp-Phone/Projects/mobile_app_distribution/migrations_generator/migrations_generator/android'), verbose_name='APK file')),
             ],
@@ -46,7 +46,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='IosApp',
             fields=[
-                ('app_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='django_mobile_app_distribution.App')),
+                ('app_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='django_mobile_app_distribution.App', on_delete=models.deletion.CASCADE)),
                 ('operating_system', models.CharField(default=b'iOS', verbose_name='Operating System', max_length=50, editable=False, choices=[(b'iOS', b'iOS'), (b'Android', b'Android')])),
                 ('app_binary', models.FileField(upload_to=django_mobile_app_distribution.models.normalize_ios_filename, verbose_name='IPA file')),
                 ('bundle_identifier', models.CharField(default=b'', help_text='e.g. org.example.app', max_length=200, verbose_name='Bundle identifier')),
@@ -63,7 +63,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('language', models.CharField(default=b'en', max_length=20, choices=[(b'en', b'English'), (b'de', b'Deutsch')])),
-                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL, on_delete=models.deletion.CASCADE)),
             ],
             options={
                 'verbose_name': 'Extended user info',
@@ -80,7 +80,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='app',
             name='user',
-            field=models.ForeignKey(related_name='apps', default=None, blank=True, to=settings.AUTH_USER_MODEL, null=True, verbose_name='User'),
+            field=models.ForeignKey(related_name='apps', default=None, blank=True, to=settings.AUTH_USER_MODEL, null=True, verbose_name='User', on_delete=models.deletion.CASCADE),
             preserve_default=True,
         ),
     ]

--- a/django_mobile_app_distribution/models.py
+++ b/django_mobile_app_distribution/models.py
@@ -4,7 +4,12 @@ import logging
 import os
 from unicodedata import normalize
 
-from django.core.urlresolvers import reverse
+import django
+if django.VERSION >= (1, 10):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
+
 from django.contrib.auth.models import User, Group
 from django.contrib.sites.models import Site
 from django.db import models

--- a/django_mobile_app_distribution/models.py
+++ b/django_mobile_app_distribution/models.py
@@ -49,7 +49,7 @@ def normalize_image_filename(instance, filename):
 
 @python_2_unicode_compatible
 class UserInfo(models.Model):
-    user = models.OneToOneField(User, verbose_name=_('user'))
+    user = models.OneToOneField(User, verbose_name=_('user'), on_delete=models.deletion.CASCADE)
     language = models.CharField(max_length=20, choices=app_dist_settings.LANGUAGES, default=app_dist_settings.ENGLISH, verbose_name=_('language'))
 
     def __str__(self):
@@ -62,7 +62,7 @@ class UserInfo(models.Model):
 
 @python_2_unicode_compatible
 class App(models.Model):
-    user = models.ForeignKey(User, blank=True, null=True, default=None, related_name='apps', verbose_name=_('User'))
+    user = models.ForeignKey(User, blank=True, null=True, default=None, related_name='apps', verbose_name=_('User'), on_delete=models.deletion.CASCADE)
     groups = models.ManyToManyField(
         Group,
         blank=True,


### PR DESCRIPTION
I updated models and migrations to comply with Django 2.0, which requires the `on_delete` parameter on ForeignKey and OneToOneField. I am still only on 1.11, but this is required to remove the deprecation warning, and I've just made the current default explicit.